### PR TITLE
Fix/parser confused by whitespace

### DIFF
--- a/ph_units/converter.py
+++ b/ph_units/converter.py
@@ -56,7 +56,7 @@ def _standardize_unit_name(_input, _unit_type_alias_dict):
         * (str): The input and output unit-type strings
     """
 
-    _input_string = str(_input).upper()
+    _input_string = str(_input).upper().strip()
     try:
         input_unit = _unit_type_alias_dict[_input_string]
     except KeyError:
@@ -68,7 +68,7 @@ def _standardize_unit_name(_input, _unit_type_alias_dict):
             )
             raise UnitTypeNameNotFound(
                 "\nI do not understand the unit: '{}'? "
-                "\nPerhaps you meant on of these: '{}'?"
+                "\nPerhaps you meant one of these: '{}'?"
                 "\n\nValid formats include only: {}".format(
                     _input_string,
                     suggested_matches,
@@ -81,7 +81,7 @@ def _standardize_unit_name(_input, _unit_type_alias_dict):
 
 def _clean_user_inputs(_input_unit, _target_unit, _unit_type_alias_dict):
     # type: (Optional[str], str, Dict[str, str]) -> Tuple[str, str]
-    """Clean and standardize the suer-input strings for the unit-types. If no
+    """Clean and standardize the user-input strings for the unit-types. If no
     input unit-type is designated, the output unit-type will be assumed to
     match the target unit-type.
 
@@ -173,7 +173,7 @@ def validate_unit_type(_unit_type):
 
     if _unit_type is None:
         return None
-
+    
     return _standardize_unit_name(_unit_type, unit_type_alias_dict)
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -33,6 +33,7 @@ def test_standardize_gives_error() -> None:
 def test_validate_unit_type() -> None:
     assert validate_unit_type("FT") == "FT"
     assert validate_unit_type("ft") == "FT"
+    assert validate_unit_type("FT ") == "FT"
     assert validate_unit_type("Btu/hr-ft2-F") == "BTU/HR-FT2-F"
     with pytest.raises(UnitTypeNameNotFound):
         validate_unit_type("Not/A-Unit")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -14,6 +14,7 @@ from ph_units.converter import (
 def test_standardize_unit_name_simple() -> None:
     assert _standardize_unit_name("FT", unit_type_alias_dict) == "FT"
     assert _standardize_unit_name("FT", unit_type_alias_dict) == "FT"
+    assert _standardize_unit_name("FT ", unit_type_alias_dict) == "FT"
 
 
 def test_standardize_unit_name_percent() -> None:
@@ -33,7 +34,6 @@ def test_standardize_gives_error() -> None:
 def test_validate_unit_type() -> None:
     assert validate_unit_type("FT") == "FT"
     assert validate_unit_type("ft") == "FT"
-    assert validate_unit_type("FT ") == "FT"
     assert validate_unit_type("Btu/hr-ft2-F") == "BTU/HR-FT2-F"
     with pytest.raises(UnitTypeNameNotFound):
         validate_unit_type("Not/A-Unit")


### PR DESCRIPTION
The component _HBPH+ — Unit Converter_ outputs an error if the string passed in has trailing whitespace.

_standardize_unit_name() now does a strip() on passed strings. 
 
fixes #4 